### PR TITLE
Fixed typo in readme

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -33,7 +33,7 @@ import React from 'react';
 import { useScss, k } from 'kremling';
 
 export function MyComponent() {
-  const scope = useScss(css);
+  const scope = useCss(css);
   return (
     <div {...scope} className="custom">
       Custom


### PR DESCRIPTION
docs currently read:
const scope = useScss(css);

should read:
const scope = useCss(css); 

Fixed this typo :)