### PR TITLE
opt out of scoping

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -67,6 +67,24 @@ Options pass-through for `sass`. Required prerequisite:
 
 Note: even if you don't need sass options, you still must pass an object for the sass compiler to run.
 
+## Opt-out of scoping
+
+Opting out of scoping from within your kremling css is a nice little escape
+hatch when you need to add some global styles. Just prepend your rules using
+the `:global` pseudo class and the plugin will omit scoping and remove that
+class:
+
+```js
+const css = k`
+  :global .test {
+    background-color: red;
+  }
+`;
+
+// css output:
+// .test { background-color: red; }
+```
+
 ## .babelrc Example
 
 ```json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kremling-babel-plugin",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "src/kremling-babel-plugin.js",
   "license": "MIT",
   "scripts": {
@@ -22,7 +22,7 @@
     "webpack-dev-server": "^3.2.1"
   },
   "dependencies": {
-    "kremling-loader": "^2.0.0",
+    "kremling-loader": "^2.1.0",
     "postcss": "^8.3.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,7 +1974,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.0, chalk@^2.4.2:
+chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4146,13 +4146,12 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-kremling-loader@^2.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/kremling-loader/-/kremling-loader-1.0.2.tgz#7c755f151b4ddc5c1424602a03e3433f7076e8cd"
-  integrity sha512-HaC3aeceLR/SqamHYX6WUCtOr4r24QpaGWj+/b5qjZ/4/BuAeKwt0Ky9O+BKhzgXcPtalh27+dVhpRodFYSqyg==
+kremling-loader@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/kremling-loader/-/kremling-loader-2.1.0.tgz#00824689591bfcfcbad09733c610f974805dfb6d"
+  integrity sha512-9sinbRrTqnV0cHMAnI0JHOncdOx5XgKW8b8GxsCvM0b08WjWvYm0Rh/cJ22QJLMZA94Nhx45xSjCNTry97ZfJw==
   dependencies:
-    loader-utils "^1.2.3"
-    postcss "^7.0.14"
+    loader-utils "^2.0.0"
     postcss-selector-parser "^5.0.0"
 
 kremling@^2.0.4:
@@ -4183,7 +4182,7 @@ loader-runner@^4.2.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
   integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
 
-loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -4191,6 +4190,15 @@ loader-utils@^1.2.3, loader-utils@^1.4.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+loader-utils@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"
+  integrity sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -4845,15 +4853,6 @@ postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
-
-postcss@^7.0.14:
-  version "7.0.35"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
-  integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
 
 postcss@^8.3.6:
   version "8.3.6"


### PR DESCRIPTION
update `kremling-loader` to v2.1.0 which includes functionality for opting out of scoping:
https://github.com/CanopyTax/kremling-loader/releases/tag/v2.1.0

also updated readme and bumped version