### PR TITLE
v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "babel-loader": "^8.0.5",
     "jest": "^26.6.3",
     "kremling": "^2.0.4",
-    "kremling-loader": "2.1.1-beta.0",
+    "kremling-loader": "^2.1.1",
     "postcss": "^8.4.13",
     "sass": "^1.32.12",
     "webpack": "^5.37.0",
@@ -24,7 +24,7 @@
     "webpack-dev-server": "^3.2.1"
   },
   "peerDependencies": {
-    "kremling-loader": ">=2",
+    "kremling-loader": ">=2.1.1",
     "postcss": ">=8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kremling-babel-plugin",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "src/kremling-babel-plugin.js",
   "license": "MIT",
   "scripts": {
@@ -16,13 +16,15 @@
     "babel-loader": "^8.0.5",
     "jest": "^26.6.3",
     "kremling": "^2.0.4",
+    "kremling-loader": "2.1.1-beta.0",
+    "postcss": "^8.4.13",
     "sass": "^1.32.12",
     "webpack": "^5.37.0",
     "webpack-cli": "^4.7.0",
     "webpack-dev-server": "^3.2.1"
   },
-  "dependencies": {
-    "kremling-loader": "^2.1.0",
-    "postcss": "^8.3.6"
+  "peerDependencies": {
+    "kremling-loader": ">=2",
+    "postcss": ">=8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "webpack-dev-server": "^3.2.1"
   },
   "peerDependencies": {
-    "kremling-loader": ">=2.1.1",
+    "kremling-loader": ">=2",
     "postcss": ">=8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4146,10 +4146,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-kremling-loader@2.1.1-beta.0:
-  version "2.1.1-beta.0"
-  resolved "https://registry.yarnpkg.com/kremling-loader/-/kremling-loader-2.1.1-beta.0.tgz#3530babf1266be1e2f2cf07e6ae40bd09313f396"
-  integrity sha512-cSEhtoKajzo202JFRsa3FRoAI+Jpe1x+/3OWzXd9Gf9Qha4hDntjfIGT9Zrpm054YH0FNCW6/ZyZKLmHqKCx+Q==
+kremling-loader@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/kremling-loader/-/kremling-loader-2.1.1.tgz#adf6b008c77cb5a247ba7b3a7b586327a671e89d"
+  integrity sha512-W9ISZJ4hqIZ1M9F29TTyfQNrR8it1AxgviZoYEWQUc8F4esO2rLC9BE9m67DlQWDiShfqXFrim9zDGGMu2399g==
   dependencies:
     loader-utils "^2.0.0"
     postcss-selector-parser "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4146,10 +4146,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-kremling-loader@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/kremling-loader/-/kremling-loader-2.1.0.tgz#00824689591bfcfcbad09733c610f974805dfb6d"
-  integrity sha512-9sinbRrTqnV0cHMAnI0JHOncdOx5XgKW8b8GxsCvM0b08WjWvYm0Rh/cJ22QJLMZA94Nhx45xSjCNTry97ZfJw==
+kremling-loader@2.1.1-beta.0:
+  version "2.1.1-beta.0"
+  resolved "https://registry.yarnpkg.com/kremling-loader/-/kremling-loader-2.1.1-beta.0.tgz#3530babf1266be1e2f2cf07e6ae40bd09313f396"
+  integrity sha512-cSEhtoKajzo202JFRsa3FRoAI+Jpe1x+/3OWzXd9Gf9Qha4hDntjfIGT9Zrpm054YH0FNCW6/ZyZKLmHqKCx+Q==
   dependencies:
     loader-utils "^2.0.0"
     postcss-selector-parser "^5.0.0"
@@ -4415,10 +4415,10 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-nanoid@^3.1.23:
-  version "3.1.23"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
-  integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
+nanoid@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -4778,6 +4778,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
@@ -4854,14 +4859,14 @@ postcss-value-parser@^4.1.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
-postcss@^8.3.6:
-  version "8.3.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.6.tgz#2730dd76a97969f37f53b9a6096197be311cc4ea"
-  integrity sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==
+postcss@^8.4.13:
+  version "8.4.13"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.13.tgz#7c87bc268e79f7f86524235821dfdf9f73e5d575"
+  integrity sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==
   dependencies:
-    colorette "^1.2.2"
-    nanoid "^3.1.23"
-    source-map-js "^0.6.2"
+    nanoid "^3.3.3"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -5533,10 +5538,10 @@ source-list-map@^2.0.1:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-js@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
-  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
# v2.0.0

- align `kremling-loader` major version with `kremling-babel-plugin` version (v2)
- move dependencies to peer deps to align better with `kremling-loader`
- change `kremling-loader` dep to major-only - all patch/minor versions of v2 must work with `kremling-loader` v2